### PR TITLE
Change `commitHash` to not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
   commitHash:
     description: 'The commit hash of the commit triggered the target deployment'
-    required: true
+    required: false
 outputs:
   id:
     description: 'Deployment ID'


### PR DESCRIPTION
Changes the commitHash property to not required, as specified in the readme