### PR TITLE
bugfix(api): Fix api reponse on build failure

### DIFF
--- a/dist/action.js
+++ b/dist/action.js
@@ -11302,20 +11302,20 @@ async function run() {
         markedAsInProgress = true;
       }
     }
-    if (latestStage.status === "failed") {
+    if (latestStage.status === "failure") {
       waiting = false;
       core.setFailed(`Deployment failed on step: ${latestStage.name}!`);
       await updateDeployment(token, deployment, "failure");
       return;
     }
-    if (latestStage.name === "deploy" && ["success", "failed"].includes(latestStage.status)) {
+    if (latestStage.name === "deploy" && ["success", "failure"].includes(latestStage.status)) {
       waiting = false;
       const aliasUrl = deployment.aliases && deployment.aliases.length > 0 ? deployment.aliases[0] : deployment.url;
       core.setOutput("id", deployment.id);
       core.setOutput("environment", deployment.environment);
       core.setOutput("url", deployment.url);
       core.setOutput("alias", aliasUrl);
-      core.setOutput("success", deployment.latest_stage.status === "success" ? true : false);
+      core.setOutput("success", deployment.latest_stage.status === "success");
       if (token !== "") {
         await updateDeployment(token, deployment, latestStage.status === "success" ? "success" : "failure");
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cf-pages-await",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cf-pages-await",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.6.0",

--- a/src/action.ts
+++ b/src/action.ts
@@ -52,14 +52,14 @@ export default async function run() {
       }
     }
 
-    if (latestStage.status === 'failed') {
+    if (latestStage.status === 'failure') {
       waiting = false;
       core.setFailed(`Deployment failed on step: ${latestStage.name}!`);
       await updateDeployment(token, deployment, 'failure');
       return;
     }
 
-    if (latestStage.name === 'deploy' && ['success', 'failed'].includes(latestStage.status)) {
+    if (latestStage.name === 'deploy' && ['success', 'failure'].includes(latestStage.status)) {
       waiting = false;
 
       const aliasUrl = deployment.aliases && deployment.aliases.length > 0 ? deployment.aliases[0] : deployment.url;
@@ -69,7 +69,7 @@ export default async function run() {
       core.setOutput('environment', deployment.environment);
       core.setOutput('url', deployment.url);
       core.setOutput('alias', aliasUrl);
-      core.setOutput('success', deployment.latest_stage.status === 'success' ? true : false);
+      core.setOutput('success', deployment.latest_stage.status === 'success');
 
       // Update deployment (if enabled)
       if (token !== '') {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -88,7 +88,7 @@ export interface Stage {
   name: 'queued'|'initialize'|'clone_repo'|'build'|'deploy';
   started_on: string;
   ended_on: string;
-  status: 'idle'|'active'|'success'|'failed'
+  status: 'idle'|'active'|'success'|'failure'
 }
 
 export interface Trigger {


### PR DESCRIPTION
On "failure" because of the new error status, the action stay stuck at ```# Now at stage: x```

Caused by an update of the api response -> https://developers.cloudflare.com/pages/platform/changelog/#support-for-d1s-new-storage-subsystem-and-build-error-message-improvements